### PR TITLE
require singleton

### DIFF
--- a/lib/aws_mfa_secure/credentials.rb
+++ b/lib/aws_mfa_secure/credentials.rb
@@ -1,3 +1,5 @@
+require "singleton"
+
 # Useful for Ruby interfacing
 module AwsMfaSecure
   class Credentials < Base


### PR DESCRIPTION
* think upstream aws-sdk libraries remove require singleton so need to require it explicitly now