### PR TITLE
fix to support latest version of AWS SDK

### DIFF
--- a/lib/aws_mfa_secure/ext/aws.rb
+++ b/lib/aws_mfa_secure/ext/aws.rb
@@ -2,14 +2,14 @@ require "aws-sdk-core"
 require "aws_mfa_secure"
 
 module AwsMfaCredentials
-  def initialize(*)
+  def initialize(access_key_id, secret_access_key, session_token = nil, **kwargs)
     credentials = AwsMfaSecure::Credentials.instance
     if credentials.set?
       @access_key_id = credentials.access_key_id
       @secret_access_key = credentials.secret_access_key
       @session_token = credentials.session_token
     else
-      super
+      super(access_key_id, secret_access_key, session_token, **kwargs)
     end
   end
 end
@@ -19,3 +19,4 @@ module Aws
     prepend AwsMfaCredentials
   end
 end
+

--- a/lib/aws_mfa_secure/version.rb
+++ b/lib/aws_mfa_secure/version.rb
@@ -1,3 +1,3 @@
 module AwsMfaSecure
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end


### PR DESCRIPTION
I was getting this error over the weekend:

```
/opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credentials.rb:11:in `initialize': wrong number of arguments (given 4, expected 2..3) (ArgumentError)
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-mfa-secure-0.4.4/lib/aws_mfa_secure/ext/aws.rb:12:in `initialize'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credential_provider_chain.rb:45:in `new'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credential_provider_chain.rb:45:in `static_credentials'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credential_provider_chain.rb:13:in `block in resolve'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credential_provider_chain.rb:12:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/credential_provider_chain.rb:12:in `resolve'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/aws-sdk-core/plugins/credentials_configuration.rb:77:in `block in <class:CredentialsConfiguration>'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:72:in `call'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:215:in `block in resolve_defaults'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:59:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:59:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:214:in `resolve_defaults'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:207:in `value_at'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:191:in `block in resolve'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/3.2.0/set.rb:511:in `each_key'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/3.2.0/set.rb:511:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:191:in `resolve'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:179:in `apply_defaults'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/configuration.rb:152:in `build!'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/base.rb:65:in `build_config'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/base.rb:21:in `initialize'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-ecr-1.86.0/lib/aws-sdk-ecr/client.rb:454:in `initialize'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.208.0/lib/seahorse/client/base.rb:102:in `new'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/aws_services.rb:46:in `ecr'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/memoist-0.16.2/lib/memoist.rb:169:in `ecr'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/ecr/auth.rb:49:in `fetch_auth_token'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/ecr/auth.rb:32:in `update'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/docker/pusher.rb:40:in `update_auth_token'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/docker/pusher.rb:16:in `push'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/cli/build.rb:22:in `docker'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/cli/ship.rb:14:in `build_task_definition'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/cli/ship.rb:7:in `run'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/cli.rb:111:in `ship'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/lib/ufo/command.rb:74:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems/ufo-6.3.13/exe/ufo:14:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/bin/ufo:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.2.5/x64/bin/ufo:25:in `<main>'
```

I am not proficient in Ruby, but this change I made fixed the issue.